### PR TITLE
Project cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,58 @@ https://user-images.githubusercontent.com/23612580/164959572-4ab5adad-eed4-46ed-
 
 ```lua
 -- Packer:
-use ({
-    'Mofiqul/trld.nvim',
-    config = function()
-        require('trld').setup({position = 'top'}) -- position: 'top' | 'bottom', default 'top'
-    end
-})
+use {'Mofiqul/trld.nvim'}
 ```
 
 
+## Configuration
+```lua
+  require('trld').setup {
+    -- where to render the diagnostics. 'top' | 'bottom'
+    position = 'top',
 
+    -- if this plugin should execute it's builtin auto commands
+    auto_cmds = true,
 
+    -- diagnostics highlight group names
+    highlights = {
+        error = "DiagnosticFloatingError",
+        warn =  "DiagnosticFloatingWarn",
+        info =  "DiagnosticFloatingInfo",
+        hint =  "DiagnosticFloatingHint",
+    },
+
+    -- diagnostics formatter. must return
+    -- {
+    --   { "String", "Highlight Group Name"},
+    --   { "String", "Highlight Group Name"},
+    --   { "String", "Highlight Group Name"},
+    --   ...
+    -- }
+    formatter = function(diag)
+        local u = require 'trld.utils'
+
+        local msg = diag.message
+        local src = diag.source
+        local code = diag.user_data.lsp.code
+
+        -- remove dots
+        msg = msg:gsub('%.', '')
+        src = src:gsub('%.', '')
+        code = code:gsub('%.', '')
+
+        -- remove starting and trailing spaces
+        msg = msg:gsub('[ \t]+%f[\r\n%z]', '')
+        src = src:gsub('[ \t]+%f[\r\n%z]', '')
+        code = code:gsub('[ \t]+%f[\r\n%z]', '')
+
+        return {
+            {msg, u.get_hl_by_serverity(diag.severity)},
+            {' ', ""},
+            {code, "Comment"},
+            {' ', ""},
+            {src, "Folded"},
+        }
+    end,
+  }
+```

--- a/lua/trld.lua
+++ b/lua/trld.lua
@@ -1,110 +1,40 @@
--- A neivim plugin to display line diagnostics on top right corner
+-- A neovim plugin to display line diagnostics on corners
 -- Last Change:	2022 Apr 23
 -- Author:	Mofiqul Islam <mofi0islam@gmail.com>
 -- Licence:	MIT
-
+local c = require 'trld.config'
+local u = require 'trld.utils'
 local M = {}
 
-local _config = {}
-
-local highlight_groups = {
-    [vim.diagnostic.severity.ERROR] = "DiagnosticError",
-    [vim.diagnostic.severity.WARN] = "DiagnosticWarn",
-    [vim.diagnostic.severity.INFO] = "DiagnosticInfo",
-    [vim.diagnostic.severity.HINT] = "DiagnosticHint",
-}
-
-local function reverse_table(table)
-    for i = 1, math.floor(#table / 2) do
-        local j = #table - i + 1
-        table[i], table[j] = table[j], table[i]
-    end
-
-    return table
-end
-
-local function show_on_top(diags, bufnr, ns)
-    local win_info = vim.fn.getwininfo(vim.fn.win_getid())[1]
-
-    for i, diag in ipairs(diags) do
-        local diag_lines = {}
-
-        for line in diag.message:gmatch("[^\n]+") do
-            table.insert(diag_lines, line)
-        end
-        for j, dline in ipairs(diag_lines) do
-            local x = (win_info.topline - 3) + (i + j)
-            if win_info.botline < x then
-                return
-            end
-            vim.api.nvim_buf_set_extmark(bufnr, ns, x, 0, {
-                virt_text = { { dline, highlight_groups[diag.severity] } },
-                virt_text_pos = "right_align",
-                virt_lines_above = true,
-            })
-        end
-    end
-
-end
-
-local function show_on_bottom(diags, bufnr, ns)
-    local win_info = vim.fn.getwininfo(vim.fn.win_getid())[1]
-    diags = reverse_table(diags)
-
-    for i, diag in ipairs(diags) do
-        local diag_lines = {}
-
-        for line in diag.message:gmatch("[^\n]+") do
-            table.insert(diag_lines, line)
-        end
-        for j, dline in ipairs(diag_lines) do
-            local x = (win_info.botline) - (i + j)
-            if win_info.topline > x then
-                return
-            end
-            vim.api.nvim_buf_set_extmark(bufnr, ns, x, 0, {
-                virt_text = { { dline, highlight_groups[diag.severity] } },
-                virt_text_pos = "right_align",
-                virt_lines_above = true,
-            })
-        end
-    end
-
-end
-
-function PrintDiagnostics(opts, bufnr, line_nr, client_id)
+function TRLDShow(opts, bufnr, line_nr, client_id)
     bufnr = bufnr or 0
     line_nr = line_nr or (vim.api.nvim_win_get_cursor(0)[1] - 1)
     opts = opts or { ['lnum'] = line_nr }
 
-    local namespace = vim.api.nvim_create_namespace "trld"
-    local ns = vim.diagnostic.get_namespace(namespace)
+    local ns = vim.api.nvim_create_namespace "trld"
+    local diag_ns = vim.diagnostic.get_namespace(ns)
 
-    local line_diagnostics = vim.diagnostic.get(bufnr, opts)
+    local line_diags = vim.diagnostic.get(bufnr, opts)
 
-    if vim.tbl_isempty(line_diagnostics) then
-
-        if ns.user_data.diags then
-            vim.api.nvim_buf_clear_namespace(bufnr, namespace, 0, -1)
+    -- clear and exit namespace if line has no diagnostics
+    if vim.tbl_isempty(line_diags) then
+        if diag_ns.user_data.diags then
+            vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
         end
         return
     end
 
-    if ns.user_data.last_line_nr == line_nr and ns.user_data.diags then
+    if diag_ns.user_data.last_line_nr == line_nr and diag_ns.user_data.diags then
         return
     end
 
-    ns.user_data.diags = true
-    ns.user_data.last_line_nr = line_nr
+    diag_ns.user_data.diags = true
+    diag_ns.user_data.last_line_nr = line_nr
 
-    if _config.position == "top" then
-        show_on_top(line_diagnostics, bufnr, namespace)
-    elseif _config.position == "bottom" then
-        show_on_bottom(line_diagnostics, bufnr, namespace)
-    end
+    u.display_diagnostics(line_diags, bufnr, ns, c.config.position)
 end
 
-function HideDiagnostics(opts, bufnr, line_nr, client_id)
+function TRLDHide(opts, bufnr, line_nr, client_id)
     bufnr = bufnr or 0
     local namespace = vim.api.nvim_get_namespaces()['trld'];
     if namespace == nil then return end
@@ -115,24 +45,17 @@ function HideDiagnostics(opts, bufnr, line_nr, client_id)
     ns.user_data.diags = false
 end
 
-M.setup = function(conf)
-    conf = conf or {}
-    if conf.position then
-        if conf.position ~= 'top' and conf.position ~= 'bottom' then
-            error(string.format("trld.nvim: Expected position to be 'top' or 'bottom', got '%s'", conf.position))
-        end
+M.setup = function(cfg)
+    -- exit if user configs are invalid
+    if not c.validate_config(cfg) then return end
 
-        _config.position = conf.position
-    else
-        _config.position = 'top'
+    -- override configs with user configs
+    c.override_config(cfg or {})
+
+    if c.config.auto_cmds then
+        vim.cmd [[ autocmd! CursorHold,CursorHoldI * lua TRLDShow() ]]
+        vim.cmd [[ autocmd! CursorMoved,CursorMovedI * lua TRLDHide() ]]
     end
-
-    vim.diagnostic.config({
-        virtual_text = false,
-    })
-
-    vim.cmd [[ autocmd! CursorHold,CursorHoldI * lua PrintDiagnostics() ]]
-    vim.cmd [[ autocmd! CursorMoved,CursorMovedI * lua HideDiagnostics() ]]
 end
 
 return M

--- a/lua/trld/config.lua
+++ b/lua/trld/config.lua
@@ -1,0 +1,54 @@
+local M = {}
+
+-- default config
+M.default_config = {
+    position = "top",
+    auto_cmds = true,
+    highlights = {
+        error = "DiagnosticFloatingError",
+        warn =  "DiagnosticFloatingWarn",
+        info =  "DiagnosticFloatingInfo",
+        hint =  "DiagnosticFloatingHint",
+    },
+    formatter = function(diag)
+        local u = require 'trld.utils'
+
+        local msg = diag.message
+        local src = diag.source
+        local code = diag.user_data.lsp.code
+
+        -- remove dots
+        msg = msg:gsub('%.', '')
+        src = src:gsub('%.', '')
+        code = code:gsub('%.', '')
+
+        -- remove starting and trailing spaces
+        msg = msg:gsub('[ \t]+%f[\r\n%z]', '')
+        src = src:gsub('[ \t]+%f[\r\n%z]', '')
+        code = code:gsub('[ \t]+%f[\r\n%z]', '')
+
+        return {
+            {msg, u.get_hl_by_serverity(diag.severity)},
+            {' ', ""},
+            {code, "Comment"},
+            {' ', ""},
+            {src, "Folded"},
+        }
+    end,
+}
+
+-- config
+M.config = {}
+
+-- return bool indicating in config is valid
+M.validate_config = function(cfg)
+    -- TODO: implement config validation with vim.notify() logging
+    return true
+end
+
+-- override the default config with user configs
+M.override_config = function(cfg)
+    M.config = vim.tbl_deep_extend("force", M.default_config, cfg or {})
+end
+
+return M

--- a/lua/trld/utils.lua
+++ b/lua/trld/utils.lua
@@ -1,0 +1,52 @@
+local M = {}
+
+local c = require 'trld.config'
+
+-- return higlight group name from lsp diagnostic severity
+M.get_hl_by_serverity = function(severity)
+    local severity_names = {
+        [vim.diagnostic.severity.ERROR] = "error",
+        [vim.diagnostic.severity.WARN] = "warn",
+        [vim.diagnostic.severity.INFO] = "info",
+        [vim.diagnostic.severity.HINT] = "hint",
+    }
+    local severity_name = severity_names[severity]
+    return c.config.highlights[severity_name]
+end
+
+-- reverse a table
+M.reverse_table = function(tbl)
+    for i = 1, math.floor(#tbl / 2) do
+        local j = #tbl - i + 1
+        tbl[i], tbl[j] = tbl[j], tbl[i]
+    end
+    return tbl
+end
+
+-- display diagnostics
+M.display_diagnostics = function(diags, bufnr, ns, pos)
+    local win_info = vim.fn.getwininfo(vim.fn.win_getid())[1]
+
+    -- reverse diag order if rendering on the bottom
+    if (pos == 'bottom') then diags = M.reverse_table(diags) end
+
+    -- render each diag
+    for i, diag in ipairs(diags) do
+        local x = nil
+        if (pos == 'top') then
+            x = (win_info.topline - 3) + (i + 1)
+            if win_info.botline < x then return end
+        elseif (pos == 'bottom') then
+            x = (win_info.botline) - (i + 1)
+            if win_info.topline > x then return end
+        end
+
+        vim.api.nvim_buf_set_extmark(bufnr, ns, x, 0, {
+            virt_text = c.config.formatter(diag),
+            virt_text_pos = "right_align",
+            virt_lines_above = true,
+        })
+    end
+end
+
+return M


### PR DESCRIPTION
I was planning to build this exact plugin today and then I saw your post on reddit and figured to contribute here instead.

this PR:
- splits the plugin into multiple module
- adds better config loading (and validation but that's a placeholder function for now)
- removes `vim.diagnostic.config({ virtual_text = false })` as that's a user preference and we shouldn't mess with that
- does lots of LSP renames (including the 2 global functions to something less likely to collide with user configs)
- changes default highlights to more appropriate ones
- unifies `show_on_top()` and `show_on_bottom()` to `display_diagnostics()` (which allows #1 to be implemented dynamically as one comment there mentioned)
- allows multiple highlight groups for different sections in every diag (more on this below)
- makes all of the above configurable

### [See it in action](https://asciinema.org/a/m8olRSTRji8wC14kDC2SOm7gT)
![image](https://user-images.githubusercontent.com/16624558/165007770-7072ab4b-b2f4-45cf-b8e7-5be40b8663e4.png)


the configs now look like
```lua
    position = "top", -- same as it was
    auto_cmds = true, -- decides if the plugin should execute its auto commands
    highlights = {...}, -- customizes diagnostic highlights
    formatter = function(diag) ... end -- takes a normal vim diag object and returns a table representing how it should be rendered (more on this bellow)
```

currently the default formatter is
```lua
    formatter = function(diag)
        local u = require 'trld.utils'

        local msg = diag.message
        local src = diag.source
        local code = diag.user_data.lsp.code

        -- remove dots
        msg = msg:gsub('%.', '')
        src = src:gsub('%.', '')
        code = code:gsub('%.', '')

        -- remove starting and trailing spaces
        msg = msg:gsub('[ \t]+%f[\r\n%z]', '')
        src = src:gsub('[ \t]+%f[\r\n%z]', '')
        code = code:gsub('[ \t]+%f[\r\n%z]', '')

        return {
            {msg, u.get_hl_by_serverity(diag.severity)},
            {' ', ""},
            {code, "Comment"},
            {' ', ""},
            {src, "Folded"},
        }
    end,
```
the returned table is in the shape of
```lua
{
  { "string", "highlight_name" },
  { "string", "highlight_name" },
  { "string", "highlight_name" },
  ...
}
```
where it can contain any number of children where each `string` is a section of the diagnostic rendered with its `highligh_name`